### PR TITLE
Fix invalid download_item list reference

### DIFF
--- a/iCloudBD/downloader.py
+++ b/iCloudBD/downloader.py
@@ -53,5 +53,5 @@ def perform_download(download_items, parallel=0):
                 pass
     else:
         with requests.session() as sess:
-            for item in download_item:
+            for item in download_items:
                 download_item(item=item, sess=sess)


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/juergen/python/iCloud-PS-Download/iCloudBD/__main__.py", line 56, in <module>
    main()
  File "/home/juergen/python/iCloud-PS-Download/iCloudBD/__main__.py", line 50, in main
    perform_download(download_items, parallel=args.parallel)
  File "/home/juergen/python/iCloud-PS-Download/iCloudBD/downloader.py", line 56, in perform_download
    for item in download_item:
TypeError: 'function' object is not iterable
```

when not using `--parallel `